### PR TITLE
Refactor web loader

### DIFF
--- a/components/DataLoader/WebLoader/WebLoader.cpp
+++ b/components/DataLoader/WebLoader/WebLoader.cpp
@@ -14,9 +14,9 @@ namespace WebLoader
         }
 
         AddThreadsCallback([this](RAGLibrary::DataExtractRequestStruct url){
-            if(auto pageData = ScrapURL(url.targetIdentifier))
+            if (auto pageData = ScrapURL(url.targetIdentifier))
             {
-                URLFontTextExtractor(*pageData, url.targetIdentifier);
+                ExtractTextFromHTML(url.targetIdentifier, *pageData);
             }
         });
     }
@@ -32,120 +32,76 @@ namespace WebLoader
         beauty::request req;
         req.set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36");
         req.method(beast::http::verb::get);
-        
+
         auto [ec, response] = client.send_request(std::move(req), std::chrono::milliseconds(0), std::string(url));
-        if(!ec)
+        if (!ec)
         {
-            if(response.status() == boost::beast::http::status::ok)
+            if (response.status() == boost::beast::http::status::ok)
             {
                 std::cout << std::format("Scrapped {}", url) << std::endl;
                 return response.body();
             }
             else
             {
-                std::cerr << std::format("Non OK status {} from response: {}({})", url,std::string(response.reason()), static_cast<int>(response.status())) << std::endl;
+                std::cerr << std::format("Non OK status {} from response: {}({})", url, std::string(response.reason()), static_cast<int>(response.status())) << std::endl;
             }
         }
         else
         {
-            std::cerr << std::format("Erro when sending request to: {} error: {}", url, ec.message()) << std::endl;
+            std::cerr << std::format("Error when sending request to: {} error: {}", url, ec.message()) << std::endl;
         }
 
         return std::nullopt;
     }
 
-    void WebLoader::URLFontTextExtractor(const std::string& urlData, const std::string& urlPath)
+    void WebLoader::ExtractTextFromHTML(const std::string& urlPath, const std::string& htmlData)
     {
-        lxb_html_document_t *document = nullptr;
-        try
+        lxb_html_document_t* document = lxb_html_document_create();
+        if (!document)
         {
-            document = lxb_html_document_create();
-            if(document == nullptr)
-            {
-                throw(RAGLibrary::RagException("Failed to create HTML document"));
-            }
+            throw RAGLibrary::RagException("Failed to create HTML document");
+        }
 
-            auto status = lxb_html_document_parse(document, reinterpret_cast<unsigned char*>(const_cast<char *>(urlData.c_str())), urlData.size());
-            if(status != LXB_STATUS_OK)
-            {
-                throw(RAGLibrary::RagException(std::format("Failed to parse HTML document with status: {}", status)));
-            }
-            
-            if(auto* body = lxb_html_document_body_element(document); body != nullptr)
-            {
-                ExtractPageTextElements(lxb_dom_interface_node(body));
-                RAGLibrary::Metadata metadata = {{"fileIdentifier", urlPath}};
-                m_dataVector.emplace_back(metadata, m_extractedText);
-                m_extractedText.clear();
-            }
-            
+        auto status = lxb_html_document_parse(document, reinterpret_cast<unsigned char*>(const_cast<char*>(htmlData.c_str())), htmlData.size());
+        if (status != LXB_STATUS_OK)
+        {
             lxb_html_document_destroy(document);
+            throw RAGLibrary::RagException(std::format("Failed to parse HTML document with status: {}", status));
         }
-        catch(const RAGLibrary::RagException& e)
+
+        RAGLibrary::Metadata metadata = { {"fileIdentifier", urlPath} };
+        RAGLibrary::LoaderDataStruct dataStruct(metadata, {});
+
+        if (auto* body = lxb_html_document_body_element(document); body != nullptr)
         {
-            if(document != nullptr) lxb_html_document_destroy(document);
-            std::cerr << e.what() << std::endl;
+            ExtractBodyText(lxb_dom_interface_node(body), dataStruct.textContent);
+        }
+        
+        lxb_html_document_destroy(document);
+        
+        {
+            std::lock_guard lock(m_mutex);
+            m_dataVector.push_back(dataStruct);
         }
     }
 
-    void WebLoader::ExtractPageTextElements(lxb_dom_node_t* node)
+    void WebLoader::ExtractBodyText(lxb_dom_node_t* node, std::vector<std::string>& textContent)
     {
-        std::string fontSize = "default";
-        auto verifyWhiteSpace = [](std::string str)
+        if (node->type == LXB_DOM_NODE_TYPE_TEXT)
         {
-            return std::all_of(str.begin(), str.end(), 
-                [](auto ch) { 
-                    return std::isspace(ch); 
-                });
-        };
-
-        if(node->type == LXB_DOM_NODE_TYPE_TEXT)
-        {
-            auto* t = lxb_dom_node_text_content(node, nullptr);
-            if(t != nullptr)
+            auto* text = lxb_dom_node_text_content(node, nullptr);
+            if (text && *text != '\0')
             {
-                std::string tStr = reinterpret_cast<char *>(const_cast<lxb_char_t *>(t));
-
-                if(tStr.size() != 0 && !verifyWhiteSpace(tStr))
+                std::string textStr(reinterpret_cast<char*>(text));
+                if (!textStr.empty() && !std::all_of(textStr.begin(), textStr.end(), isspace))
                 {
-                    GetFontSize(node->parent, fontSize);
-                    {
-                        std::lock_guard lock(m_mutex);
-                        m_extractedText.push_back(std::format("font-size: {}, text: {}",fontSize, tStr));
-                    }
+                    textContent.push_back(textStr);
                 }
             }
         }
-        auto* child = lxb_dom_node_first_child(node);
-        while(child != nullptr)
+        for (auto* child = lxb_dom_node_first_child(node); child; child = lxb_dom_node_next(child))
         {
-            ExtractPageTextElements(child);
-            child = lxb_dom_node_next(child);
+            ExtractBodyText(child, textContent);
         }
     }
-
-    void WebLoader::GetFontSize(lxb_dom_node_t* node, std::string& fontSize)
-    {
-        while(node)
-        {
-            if(node->type == LXB_DOM_NODE_TYPE_ELEMENT)
-            {
-                auto* elem = lxb_dom_interface_element(node);
-                auto* attr = lxb_dom_element_get_attribute(elem, reinterpret_cast<lxb_char_t *>(const_cast<char *>("style")), 5, nullptr);
-                if(attr)
-                {
-                    std::string style(reinterpret_cast<char *>(const_cast<lxb_char_t *>(attr)));
-
-                    if(RE2::PartialMatch(style, fontSizeRegex, &fontSize))
-                    {
-                        return;
-                    }
-                }
-            }
-            node = lxb_dom_node_parent(node);
-        }
-    }
-
-
-
 }

--- a/components/DataLoader/WebLoader/WebLoader.h
+++ b/components/DataLoader/WebLoader/WebLoader.h
@@ -4,32 +4,30 @@
 #include <string>
 #include <memory>
 #include <optional>
+#include <mutex>
 
 #include "BaseLoader.h"
-
 #include "lexbor/html/html.h"
-#include "re2/re2.h"
+#include "beauty/beauty.hpp"
 
 namespace WebLoader
 {
-    const RE2 fontSizeRegex("font-size:\\s*([\\d\\.]+\\w+%?);?");
-    
     class WebLoader : public DataLoader::BaseDataLoader
     {
     public:
         WebLoader() = delete;
-        WebLoader(const std::vector<RAGLibrary::DataExtractRequestStruct>& urlsToScrap = {}, const int& numThreads = 0);
+        WebLoader(const std::vector<RAGLibrary::DataExtractRequestStruct> &urlsToScrap = {}, const int &numThreads = 0);
         ~WebLoader() = default;
 
-        void InsertDataToExtract(const std::vector<RAGLibrary::DataExtractRequestStruct>& dataPaths) final;
+        void InsertDataToExtract(const std::vector<RAGLibrary::DataExtractRequestStruct> &dataPaths) final;
+
     private:
-        std::optional<std::string> ScrapURL(const std::string& url);
-        void URLFontTextExtractor(const std::string& urlData, const std::string& urlPath);
-        void ExtractPageTextElements(lxb_dom_node_t* node);
-        void GetFontSize(lxb_dom_node_t* node, std::string& fontSize);
+        std::optional<std::string> ScrapURL(const std::string &url);
+        void ExtractTextFromHTML(const std::string &urlPath, const std::string &htmlData);
+        void ExtractBodyText(lxb_dom_node_t *node, std::vector<std::string> &textContent);
 
         mutable std::mutex m_mutex;
-        std::vector<std::string> m_extractedText;
+        std::vector<RAGLibrary::LoaderDataStruct> m_dataVector;
     };
     using WebLoaderPtr = std::shared_ptr<WebLoader>;
 }


### PR DESCRIPTION
- Introduced RAGLibrary::LoaderDataStruct to store metadata and extracted content in a more structured way.
- Removed font size extraction logic (GetFontSize), focusing only on textual content.
- Simplified ExtractPageTextElements, now ExtractBodyText, eliminating unnecessary checks.
- Protected m_dataVector with std::lock_guard, preventing race conditions.