### PR TITLE
Vector Database Structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,26 @@ find_package(Torch REQUIRED)
 include_directories("${CMAKE_SOURCE_DIR}/libs/libtorch/cpu/include")
 link_directories("${CMAKE_SOURCE_DIR}/libs/libtorch/cpu/lib")
 
+# ------------------------------------------------------------------
+# === VectorDatabase =================================================
+# (cole este bloco após a seção de find_package já existente,
+#  antes de criar/alocar alvos que precisem dele)
+# ------------------------------------------------------------------
+find_package(redis++ REQUIRED)            # hiredis vem junto
+
+file(GLOB_RECURSE VDB_SRCS
+     ${CMAKE_SOURCE_DIR}/components/VectorDatabase/src/*.cpp)
+file(GLOB_RECURSE VDB_INCS
+     ${CMAKE_SOURCE_DIR}/components/VectorDatabase/include/vectordb/*.h)
+
+add_library(VectorDatabase STATIC ${VDB_SRCS} ${VDB_INCS})
+target_include_directories(VectorDatabase PUBLIC
+    ${CMAKE_SOURCE_DIR}/components/VectorDatabase/include)
+
+#  --- o gerador do Conan expõe ‘redis++::redis++_static’
+
+
+
 set(CMAKE_BUILD_RPATH
     "${PYTHON_SITE_PACKAGES}/*/d_libs/libtorch/cpu/lib"
     "\$ORIGIN/purecpp.libs"
@@ -174,6 +194,30 @@ target_link_libraries(RagPUREAILib PUBLIC #.lib e .dll
     ${TORCH_LIBRARIES}
 )
 
+
+target_link_libraries(VectorDatabase
+    PUBLIC nlohmann_json::nlohmann_json redis++::redis++_static hiredis::hiredis)
+
 # Pybind11 Module
 pybind11_add_module(RagPUREAI ${RagPUREAI_BINDING_SRCS})
 target_link_libraries(RagPUREAI PRIVATE RagPUREAILib)
+
+pybind11_add_module(vectordb components/VectorDatabase/python/_vectordb.cpp)
+
+if (MSVC)
+    target_link_options(vectordb PRIVATE "/WHOLEARCHIVE:VectorDatabase")
+elseif(APPLE)
+    # clang/ld64
+    target_link_libraries(vectordb PRIVATE "-Wl,-force_load" VectorDatabase)
+else()
+    # gcc/clang + GNU ld or gold
+    target_link_libraries(vectordb PRIVATE -Wl,--whole-archive VectorDatabase -Wl,--no-whole-archive)
+endif()
+
+# libs extras que o módulo precisa além do VectorDatabase (se necessário)
+target_link_libraries(vectordb PRIVATE nlohmann_json::nlohmann_json redis++::redis++_static hiredis::hiredis)
+
+set_target_properties(vectordb PROPERTIES
+    OUTPUT_NAME "vectordb"
+    LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,25 +71,26 @@ find_package(Torch REQUIRED)
 include_directories("${CMAKE_SOURCE_DIR}/libs/libtorch/cpu/include")
 link_directories("${CMAKE_SOURCE_DIR}/libs/libtorch/cpu/lib")
 
-# ------------------------------------------------------------------
-# === VectorDatabase =================================================
-# (cole este bloco após a seção de find_package já existente,
-#  antes de criar/alocar alvos que precisem dele)
-# ------------------------------------------------------------------
-find_package(redis++ REQUIRED)            # hiredis vem junto
+# -------------------------------------------------------
+# === VectorDatabase (lib C++) ==========================
+# -------------------------------------------------------
+find_package(redis++ REQUIRED)   # hiredis vem junto
 
-file(GLOB_RECURSE VDB_SRCS
-     ${CMAKE_SOURCE_DIR}/components/VectorDatabase/src/*.cpp)
-file(GLOB_RECURSE VDB_INCS
-     ${CMAKE_SOURCE_DIR}/components/VectorDatabase/include/vectordb/*.h)
+file(GLOB_RECURSE VDB_SRCS  ${CMAKE_SOURCE_DIR}/components/VectorDatabase/src/*.cpp)
+file(GLOB_RECURSE VDB_INCS  ${CMAKE_SOURCE_DIR}/components/VectorDatabase/include/vectordb/*.h)
 
 add_library(VectorDatabase STATIC ${VDB_SRCS} ${VDB_INCS})
 target_include_directories(VectorDatabase PUBLIC
-    ${CMAKE_SOURCE_DIR}/components/VectorDatabase/include)
+    ${CMAKE_SOURCE_DIR}/components/VectorDatabase/include
+)
+target_link_libraries(VectorDatabase
+    PUBLIC
+        nlohmann_json::nlohmann_json
+        redis++::redis++_static
+        hiredis::hiredis
+)
 
-#  --- o gerador do Conan expõe ‘redis++::redis++_static’
-
-
+# ------------------------------------------------------------------
 
 set(CMAKE_BUILD_RPATH
     "${PYTHON_SITE_PACKAGES}/*/d_libs/libtorch/cpu/lib"
@@ -194,30 +195,31 @@ target_link_libraries(RagPUREAILib PUBLIC #.lib e .dll
     ${TORCH_LIBRARIES}
 )
 
-
-target_link_libraries(VectorDatabase
-    PUBLIC nlohmann_json::nlohmann_json redis++::redis++_static hiredis::hiredis)
-
-# Pybind11 Module
+# -------------------------------------------------------
+# === Pybind11 Modules ==================================
+# -------------------------------------------------------
+# RagPUREAI
 pybind11_add_module(RagPUREAI ${RagPUREAI_BINDING_SRCS})
 target_link_libraries(RagPUREAI PRIVATE RagPUREAILib)
 
+# vectordb  
 pybind11_add_module(vectordb components/VectorDatabase/python/_vectordb.cpp)
+target_link_libraries(vectordb PRIVATE
+    -Wl,--whole-archive
+    VectorDatabase
+    -Wl,--no-whole-archive
+)
 
-if (MSVC)
-    target_link_options(vectordb PRIVATE "/WHOLEARCHIVE:VectorDatabase")
-elseif(APPLE)
-    # clang/ld64
-    target_link_libraries(vectordb PRIVATE "-Wl,-force_load" VectorDatabase)
-else()
-    # gcc/clang + GNU ld or gold
-    target_link_libraries(vectordb PRIVATE -Wl,--whole-archive VectorDatabase -Wl,--no-whole-archive)
-endif()
+# Disables LTO/IPO in the module to avoid ODR/refcount problems.
 
-# libs extras que o módulo precisa além do VectorDatabase (se necessário)
-target_link_libraries(vectordb PRIVATE nlohmann_json::nlohmann_json redis++::redis++_static hiredis::hiredis)
+set_property(TARGET vectordb PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+target_compile_options(vectordb PRIVATE -fno-lto)
+target_link_options(vectordb PRIVATE -fno-lto)
 
+# .so output
 set_target_properties(vectordb PROPERTIES
     OUTPUT_NAME "vectordb"
-    LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python
+    LIBRARY_OUTPUT_DIRECTORY  "${PROJECT_BINARY_DIR}/python"
+    ARCHIVE_OUTPUT_DIRECTORY  "${PROJECT_BINARY_DIR}/python"
+    RUNTIME_OUTPUT_DIRECTORY  "${PROJECT_BINARY_DIR}/python"
 )

--- a/components/VectorDatabase/include/vectordb/backend.h
+++ b/components/VectorDatabase/include/vectordb/backend.h
@@ -22,12 +22,13 @@ public:
            query(std::span<const float> embedding, std::size_t k,
                  const std::unordered_map<std::string,std::string>* filter=nullptr) = 0;
 
-    // opcionais
+    
     virtual void close() {}
 protected:
     std::uint32_t dim_;
 };
 
-using VectorBackendPtr = std::unique_ptr<VectorBackend>;
+using VectorBackendPtr = std::shared_ptr<VectorBackend>;
+
 
 } // namespace vdb

--- a/components/VectorDatabase/include/vectordb/backend.h
+++ b/components/VectorDatabase/include/vectordb/backend.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "document.h"
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace vdb {
+
+struct QueryResult { Document doc; float score; };
+
+class VectorBackend {
+public:
+    explicit VectorBackend(std::uint32_t dim) : dim_(dim) {}
+    virtual ~VectorBackend()                           = default;
+
+    std::uint32_t dim() const noexcept { return dim_; }
+    virtual bool  is_open() const noexcept            = 0;
+
+    virtual void insert(std::span<const Document> docs)            = 0;
+    virtual std::vector<QueryResult>
+           query(std::span<const float> embedding, std::size_t k,
+                 const std::unordered_map<std::string,std::string>* filter=nullptr) = 0;
+
+    // opcionais
+    virtual void close() {}
+protected:
+    std::uint32_t dim_;
+};
+
+using VectorBackendPtr = std::unique_ptr<VectorBackend>;
+
+} // namespace vdb

--- a/components/VectorDatabase/include/vectordb/document.h
+++ b/components/VectorDatabase/include/vectordb/document.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace vdb {
+
+struct Document {
+    std::string                                   page_content;
+    std::vector<float>                            embedding;
+    std::unordered_map<std::string, std::string>  metadata;
+
+    std::size_t dim() const noexcept { return embedding.size(); }
+
+    // serialização simples (para Redis, log, etc.)
+    [[nodiscard]] std::string to_json() const;
+    static Document from_json(std::string_view json);
+};
+
+} // namespace vdb

--- a/components/VectorDatabase/include/vectordb/document.h
+++ b/components/VectorDatabase/include/vectordb/document.h
@@ -12,7 +12,6 @@ struct Document {
 
     std::size_t dim() const noexcept { return embedding.size(); }
 
-    // serialização simples (para Redis, log, etc.)
     [[nodiscard]] std::string to_json() const;
     static Document from_json(std::string_view json);
 };

--- a/components/VectorDatabase/include/vectordb/exceptions.h
+++ b/components/VectorDatabase/include/vectordb/exceptions.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <stdexcept>
+
+namespace vdb {
+struct VStoreError         : std::runtime_error { using std::runtime_error::runtime_error; };
+struct InvalidConfiguration: VStoreError { using VStoreError::VStoreError; };
+struct BackendClosed       : VStoreError { using VStoreError::VStoreError; };
+struct DimensionMismatch   : VStoreError { using VStoreError::VStoreError; };
+struct QueryError          : VStoreError { using VStoreError::VStoreError; };
+struct InsertionError      : VStoreError { using VStoreError::VStoreError; };
+} // namespace vdb

--- a/components/VectorDatabase/include/vectordb/registry.h
+++ b/components/VectorDatabase/include/vectordb/registry.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "backend.h"
+
+#include <nlohmann/json.hpp>   // <-- garante que nlohmann::json seja visível
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace vdb {
+
+class Registry {
+public:
+    using Factory = std::function<VectorBackendPtr(const nlohmann::json&)>;
+
+    static Registry& instance();
+
+    void register_backend(const std::string& name,
+                          Factory factory,
+                          bool allow_override = false);
+
+    [[nodiscard]] VectorBackendPtr make(const std::string& name,
+                                        const nlohmann::json& cfg) const;
+
+    [[nodiscard]] std::vector<std::string> list() const;
+
+private:
+    Registry() = default;
+    Registry(const Registry&) = delete;
+    Registry& operator=(const Registry&) = delete;
+
+    mutable std::mutex               mtx_;
+    std::map<std::string, Factory>   factories_;
+};
+
+template <class Concrete>
+struct AutoRegister {
+    explicit AutoRegister(const std::string& name) {
+        Registry::instance().register_backend(
+            name,
+            [](const nlohmann::json& cfg) {
+                return std::make_unique<Concrete>(cfg);
+            });
+    }
+};
+
+} // namespace vdb

--- a/components/VectorDatabase/include/vectordb/registry.h
+++ b/components/VectorDatabase/include/vectordb/registry.h
@@ -2,7 +2,7 @@
 
 #include "backend.h"
 
-#include <nlohmann/json.hpp>   // <-- garante que nlohmann::json seja visível
+#include <nlohmann/json.hpp>   
 #include <functional>
 #include <map>
 #include <mutex>
@@ -41,7 +41,7 @@ struct AutoRegister {
         Registry::instance().register_backend(
             name,
             [](const nlohmann::json& cfg) {
-                return std::make_unique<Concrete>(cfg);
+                return std::make_shared<Concrete>(cfg); // <-- Use make_shared
             });
     }
 };

--- a/components/VectorDatabase/include/vectordb/wrappers/concurrent.h
+++ b/components/VectorDatabase/include/vectordb/wrappers/concurrent.h
@@ -34,7 +34,6 @@ public:
 
     ~ConcurrentSearchWrapper() override;
 
-    /* ---------------- VectorBackend interface ---------------- */
     [[nodiscard]] bool is_open() const noexcept override;
     void insert(std::span<const Document> docs) override;
 
@@ -43,14 +42,12 @@ public:
           std::size_t                         k,
           const std::unordered_map<std::string, std::string>* filter = nullptr) override;
 
-    /* ------------ new helper: batch execution ---------------- */
     std::vector<std::vector<QueryResult>>
     query_many(const std::vector<std::vector<float>>&            embeddings,
                std::size_t                                       k           = 5,
                const std::unordered_map<std::string, std::string>* filter    = nullptr,
                bool                                              raiseOnErr = false);
 
-    /* ---------------- lifecycle delegation ------------------- */
     void close() override;
 
 private:

--- a/components/VectorDatabase/include/vectordb/wrappers/concurrent.h
+++ b/components/VectorDatabase/include/vectordb/wrappers/concurrent.h
@@ -1,0 +1,63 @@
+#pragma once
+/**
+ * ConcurrentSearchWrapper
+ * -----------------------
+ * A thin, thread-pool façade around any VectorBackend.
+ *
+ *  • Inserts are serialised (they mutate state).
+ *  • Queries can run in parallel as long as the wrapped backend
+ *    is thread-safe for `query()`; otherwise we serialise them too.
+ *
+ * Build-only dependency: <future> / <thread> (no Boost/TBB needed).
+ */
+#include <future>
+#include <mutex>
+#include <span>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "vectordb/backend.h"
+
+namespace vdb::wrappers {
+
+class ConcurrentSearchWrapper final : public VectorBackend {
+public:
+    /** 
+     * @param backend          Ownership is transferred (unique_ptr)
+     * @param maxWorkers       #threads in the internal pool (0 → hw concurrency)
+     * @param backendThreadSafe If false we serialise every call to query()
+     */
+    explicit ConcurrentSearchWrapper(VectorBackendPtr backend,
+                                     std::size_t      maxWorkers        = std::thread::hardware_concurrency(),
+                                     bool             backendThreadSafe = true);
+
+    ~ConcurrentSearchWrapper() override;
+
+    /* ---------------- VectorBackend interface ---------------- */
+    [[nodiscard]] bool is_open() const noexcept override;
+    void insert(std::span<const Document> docs) override;
+
+    std::vector<QueryResult>
+    query(std::span<const float>               embedding,
+          std::size_t                         k,
+          const std::unordered_map<std::string, std::string>* filter = nullptr) override;
+
+    /* ------------ new helper: batch execution ---------------- */
+    std::vector<std::vector<QueryResult>>
+    query_many(const std::vector<std::vector<float>>&            embeddings,
+               std::size_t                                       k           = 5,
+               const std::unordered_map<std::string, std::string>* filter    = nullptr,
+               bool                                              raiseOnErr = false);
+
+    /* ---------------- lifecycle delegation ------------------- */
+    void close() override;
+
+private:
+    VectorBackendPtr backend_;
+    std::size_t      workers_;
+    bool             backendThreadSafe_;
+    std::mutex       mtx_;        // protects non-thread-safe back-ends
+};
+
+}  // namespace vdb::wrappers

--- a/components/VectorDatabase/include/vectordb/wrappers/metrics.h
+++ b/components/VectorDatabase/include/vectordb/wrappers/metrics.h
@@ -1,0 +1,71 @@
+#pragma once
+/**
+ * MetricsWrapper
+ * --------------
+ * Coleta estatísticas de uso (contagem, erros, latência) de qualquer
+ * `VectorBackend`.  Tudo thread-safe.
+ *
+ *  • Não adiciona dependências externas – só STL.
+ *  • Exponha as métricas via `snapshot()` (C++ map) ou
+ *    `snapshot_json()` (string JSON usando nlohmann/json).
+ *  • Se quiser Prometheus, é fácil plugar depois (ver TODO no .cpp).
+ */
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "vectordb/backend.h"
+
+namespace vdb::wrappers {
+
+struct CallStats {
+    std::uint64_t calls   = 0;
+    std::uint64_t errors  = 0;
+    double        total   = 0.0;          // segundos acumulados
+    double        min_t   = std::numeric_limits<double>::infinity();
+    double        max_t   = 0.0;
+
+    void observe(double elapsed, bool ok) noexcept;
+};
+
+/**
+ * Wrapper propriamente dito.
+ */
+class MetricsWrapper final : public VectorBackend {
+public:
+    explicit MetricsWrapper(VectorBackendPtr backend,
+                            std::string       namespace_ = "vdb");
+
+    /* ------------- VectorBackend interface ----------------- */
+    [[nodiscard]] bool is_open() const noexcept override;
+    void insert(std::span<const Document> docs) override;
+    std::vector<QueryResult>
+    query(std::span<const float>               embedding,
+          std::size_t                         k,
+          const std::unordered_map<std::string,std::string>* filter = nullptr) override;
+
+    /* delega extras se o backend suportar ------------------- */
+    void close() override;
+
+    /* ------------- API de métricas ------------------------ */
+    [[nodiscard]]
+    std::unordered_map<std::string, CallStats> snapshot() const;
+
+    [[nodiscard]] std::string snapshot_json(int indent = 2) const;
+
+    void reset();
+
+private:
+    /* util interno que mede + propaga */
+    template<typename F, typename... Args>
+    auto measure(const std::string& method, F&& fn, Args&&... args);
+
+    VectorBackendPtr                                       backend_;
+    mutable std::mutex                                     mtx_;
+    std::unordered_map<std::string, CallStats>             stats_;
+    const std::string                                      ns_;     // p/ futuramente exp-Prometheus
+};
+
+}  // namespace vdb::wrappers

--- a/components/VectorDatabase/python/_vectordb.cpp
+++ b/components/VectorDatabase/python/_vectordb.cpp
@@ -1,0 +1,61 @@
+// python/_vectordb.cpp
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>          // std::vector, std::unordered_map, …
+#include "vectordb/document.h"
+#include "vectordb/registry.h"
+#include "vectordb/backend.h"
+
+namespace py = pybind11;
+using namespace vdb;
+
+PYBIND11_MODULE(vectordb, m) {
+    m.doc() = "Python bindings para VectorDatabase (PureCPP)";
+
+    /* ------------------------ Document ----------------------- */
+    py::class_<Document>(m, "Document")
+        .def(py::init<std::string, std::vector<float>,
+                      std::unordered_map<std::string, std::string>>(),
+             py::arg("page_content"),
+             py::arg("embedding"),
+             py::arg("metadata") = std::unordered_map<std::string,std::string>())
+        .def_readwrite("page_content", &Document::page_content)
+        .def_readwrite("embedding",    &Document::embedding)
+        .def_readwrite("metadata",     &Document::metadata)
+        .def("__len__", &Document::dim)
+        .def("__repr__", [](const Document& d){
+            return "<Document dim=" + std::to_string(d.dim()) + ">";
+        });
+
+    /* ------------------------ VectorBackend ------------------ */
+    py::class_<VectorBackend, std::shared_ptr<VectorBackend>>(m, "VectorBackend")
+        .def("insert",  &VectorBackend::insert,
+             py::arg("docs"),
+             "Insere uma lista de Document")
+        .def("query",   &VectorBackend::query,
+             py::arg("embedding"), py::arg("k") = 5,
+             py::arg("filter") = nullptr,
+             "Retorna top-k (doc, score)");
+
+    /* ----------------------- Factory ------------------------- */
+    m.def("make_backend",
+          [](const std::string& name,
+             const std::string& json_cfg) -> std::shared_ptr<VectorBackend>
+          {
+              auto cfg = nlohmann::json::parse(json_cfg);
+              return Registry::instance().make(name, cfg);
+          },
+          py::arg("name"), py::arg("json_cfg"),
+          R"pbdoc(
+              Instancia o backend solicitado.
+              Exemplo:
+                  store = vectordb.make_backend(
+                      "redis",
+                      '{"dim": 768, "uri": "tcp://localhost:6379"}'
+                  )
+          )pbdoc");
+
+    /* ----------------------- Utilidades ---------------------- */
+    m.def("list_backends", []{
+        return Registry::instance().list();
+    });
+}

--- a/components/VectorDatabase/python/_vectordb.cpp
+++ b/components/VectorDatabase/python/_vectordb.cpp
@@ -1,61 +1,100 @@
-// python/_vectordb.cpp
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>          // std::vector, std::unordered_map, …
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+#include <nlohmann/json.hpp>
+
 #include "vectordb/document.h"
-#include "vectordb/registry.h"
 #include "vectordb/backend.h"
+#include "vectordb/registry.h"
+
+#include <cstring>
 
 namespace py = pybind11;
 using namespace vdb;
 
-PYBIND11_MODULE(vectordb, m) {
-    m.doc() = "Python bindings para VectorDatabase (PureCPP)";
+static std::vector<float> to_vecf(const py::handle& obj) {
+    if (py::isinstance<py::array>(obj)) {
+        py::array arr = py::cast<py::array>(obj);
+        if (arr.ndim() != 1) throw std::runtime_error("The embedding should be 1D.");
+        std::vector<float> v(arr.size());
+        std::memcpy(v.data(), arr.data(), arr.size() * sizeof(float));
+        return v;
+    }
+    return py::cast<std::vector<float>>(obj);
+}
 
-    /* ------------------------ Document ----------------------- */
+PYBIND11_MODULE(vectordb, m) {
+    m.doc() = "Python bindings for VectorDatabase (PureCPP)";
+
+    
     py::class_<Document>(m, "Document")
-        .def(py::init<std::string, std::vector<float>,
-                      std::unordered_map<std::string, std::string>>(),
+        .def(py::init<std::string,
+                      std::vector<float>,
+                      std::unordered_map<std::string,std::string>>(),
              py::arg("page_content"),
              py::arg("embedding"),
-             py::arg("metadata") = std::unordered_map<std::string,std::string>())
+             py::arg("metadata") = std::unordered_map<std::string,std::string>{})
+        .def_property_readonly("dim", &Document::dim)
         .def_readwrite("page_content", &Document::page_content)
         .def_readwrite("embedding",    &Document::embedding)
         .def_readwrite("metadata",     &Document::metadata)
-        .def("__len__", &Document::dim)
+        .def("to_json",   &Document::to_json)
+        .def_static("from_json", [](const std::string& s){ return Document::from_json(s); })
         .def("__repr__", [](const Document& d){
             return "<Document dim=" + std::to_string(d.dim()) + ">";
         });
 
-    /* ------------------------ VectorBackend ------------------ */
-    py::class_<VectorBackend, std::shared_ptr<VectorBackend>>(m, "VectorBackend")
-        .def("insert",  &VectorBackend::insert,
-             py::arg("docs"),
-             "Insere uma lista de Document")
-        .def("query",   &VectorBackend::query,
-             py::arg("embedding"), py::arg("k") = 5,
-             py::arg("filter") = nullptr,
-             "Retorna top-k (doc, score)");
 
-    /* ----------------------- Factory ------------------------- */
+    py::class_<QueryResult>(m, "QueryResult")
+        .def_readonly("doc",   &QueryResult::doc)    
+        .def_readonly("score", &QueryResult::score)
+        .def("__repr__", [](const QueryResult& r){
+            return "<QueryResult score=" + std::to_string(r.score) + ">";
+        });
+
+    
+    py::class_<VectorBackend, std::shared_ptr<VectorBackend>>(m, "VectorBackend")
+        .def("insert", [](VectorBackend& self, py::object py_docs){
+            std::vector<Document> docs;
+            if (py::isinstance<py::list>(py_docs)) {
+                for (py::handle h : py_docs) docs.push_back(py::cast<Document>(h));
+            } else {
+                docs.push_back(py::cast<Document>(py_docs));
+            }
+            self.insert(docs);
+        }, py::arg("docs"), "Inserts one or a list of Documents..")
+        .def("query", [](VectorBackend& self,
+                         py::object embedding,
+                         std::size_t k,
+                         py::object filt_obj){
+            auto emb = to_vecf(embedding);
+
+            std::unordered_map<std::string,std::string> filt;
+            const std::unordered_map<std::string,std::string>* pf = nullptr;
+            if (!filt_obj.is_none()) {
+                filt = py::cast<std::unordered_map<std::string,std::string>>(filt_obj);
+                pf = &filt;
+            }
+            return self.query(emb, k, pf);
+        }, py::arg("embedding"), py::arg("k") = 5, py::arg("filter") = py::none(),
+           "Executes a KNN search and returns a list of QueryResult.")
+        .def("is_open", &VectorBackend::is_open)
+        .def("close",   &VectorBackend::close)
+        .def("__repr__", [](const VectorBackend&){
+            return "<VectorBackend>";
+        });
+
+    
     m.def("make_backend",
-          [](const std::string& name,
-             const std::string& json_cfg) -> std::shared_ptr<VectorBackend>
-          {
+          [](const std::string& name, const std::string& json_cfg){
               auto cfg = nlohmann::json::parse(json_cfg);
               return Registry::instance().make(name, cfg);
           },
           py::arg("name"), py::arg("json_cfg"),
-          R"pbdoc(
-              Instancia o backend solicitado.
-              Exemplo:
-                  store = vectordb.make_backend(
-                      "redis",
-                      '{"dim": 768, "uri": "tcp://localhost:6379"}'
-                  )
-          )pbdoc");
+          "Instantiates a registered backend from a configuration JSON.");
 
-    /* ----------------------- Utilidades ---------------------- */
     m.def("list_backends", []{
         return Registry::instance().list();
-    });
+    }, "Lists the registered backends..");
 }

--- a/components/VectorDatabase/src/backends/redis_backend.cpp
+++ b/components/VectorDatabase/src/backends/redis_backend.cpp
@@ -1,0 +1,280 @@
+// redis_backend.cpp
+#include "vectordb/backend.h"
+#include "vectordb/registry.h"
+#include "vectordb/exceptions.h"
+#include "vectordb/document.h"
+
+#include <nlohmann/json.hpp>
+#include <sw/redis++/redis++.h>
+#include <hiredis/hiredis.h>
+
+#include <random>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include <cstring>   // memcpy
+#include <stdexcept>
+
+namespace vdb {
+
+class RedisVectorBackend final : public VectorBackend {
+    using redis_t = sw::redis::Redis;
+
+public:
+    explicit RedisVectorBackend(const nlohmann::json& cfg)
+        : VectorBackend(cfg.at("dim").get<std::uint32_t>())
+        , redis_(std::make_shared<redis_t>(cfg.value("uri", "tcp://127.0.0.1:6379")))
+        , index_(cfg.value("index",  "vstore_idx"))
+        , prefix_(cfg.value("prefix", "doc"))
+        , metric_(cfg.value("metric", "COSINE"))  // "COSINE" | "L2" | "IP"
+    {
+        ensure_index(cfg.value("capacity", 0));
+    }
+
+    bool is_open() const noexcept override { return static_cast<bool>(redis_); }
+
+    /* ----------------------------- insert ----------------------------- */
+    void insert(std::span<const Document> docs) override {
+        if (!is_open()) throw BackendClosed("Redis backend closed");
+
+        auto pipe = redis_->pipeline(false); // non-atomic for throughput
+
+        for (const auto& d : docs) {
+            if (d.dim() != dim_) throw DimensionMismatch("Dimension mismatch on insert");
+
+            const std::string key = prefix_ + ":" + gen_uuid();
+
+            // serialize embedding
+            const std::string binary(reinterpret_cast<const char*>(d.embedding.data()),
+                                     d.embedding.size() * sizeof(float));
+
+            pipe.hset(key, std::initializer_list<std::pair<std::string,std::string>>{
+                {"vector",   binary},
+                {"page",     d.page_content},
+                {"metadata", d.to_json()}
+            });
+        }
+
+        try {
+            pipe.exec();
+        } catch (const sw::redis::Error& e) {
+            throw InsertionError(e.what());
+        }
+    }
+
+    /* ------------------------------ query ----------------------------- */
+    std::vector<QueryResult>
+    query(std::span<const float> embedding,
+          std::size_t k,
+          const std::unordered_map<std::string, std::string>* filter) override {
+
+        if (embedding.size() != dim_) throw DimensionMismatch("Dimension mismatch on query");
+
+        const std::string vec_bin(reinterpret_cast<const char*>(embedding.data()),
+                                  embedding.size() * sizeof(float));
+
+        std::string base = "*";
+        if (filter && !filter->empty()) {
+            std::string f;
+            for (const auto& [field, value] : *filter) {
+                (void)field; // metadata blob -> contains
+                f += "@metadata:\"" + value + "\" ";
+            }
+            base = std::move(f);
+        }
+
+        const std::string knn_clause =
+            "=>[KNN " + std::to_string(k) + " @vector $vec AS score]";
+        const std::string q = base + " " + knn_clause;
+
+        // Monta argv para FT.SEARCH
+        std::vector<std::string> argv = {
+            "FT.SEARCH",
+            index_,
+            q,
+            "PARAMS", "2", "vec", vec_bin,
+            "RETURN", "3", "page", "metadata", "vector",
+            "DIALECT", "2",
+            "SORTBY", "score", "ASC"
+        };
+
+        sw::redis::ReplyUPtr reply;
+        try {
+            reply = redis_->command(argv.begin(), argv.end());
+        } catch (const sw::redis::Error& e) {
+            throw QueryError(e.what());
+        }
+
+        std::vector<std::string> flat;
+        flatten_reply(reply.get(), flat);
+        return parse_search_reply(flat, prefix_);
+    }
+
+    void close() override { redis_.reset(); }
+
+private:
+    std::shared_ptr<redis_t> redis_;
+    std::string              index_, prefix_, metric_;
+
+    /* ------------------------- helpers ------------------------- */
+
+    static void flatten_reply(const redisReply* r, std::vector<std::string>& out) {
+        if (!r) return;
+        switch (r->type) {
+        case REDIS_REPLY_STRING:
+        case REDIS_REPLY_STATUS:
+        case REDIS_REPLY_ERROR:
+            out.emplace_back(r->str ? r->str : "");
+            break;
+        case REDIS_REPLY_INTEGER:
+            out.emplace_back(std::to_string(r->integer));
+            break;
+        case REDIS_REPLY_NIL:
+            out.emplace_back(""); // representa NIL como string vazia
+            break;
+        case REDIS_REPLY_ARRAY:
+            for (size_t i = 0; i < r->elements; ++i)
+                flatten_reply(r->element[i], out);
+            break;
+#if HIREDIS_MAJOR >= 1
+        case REDIS_REPLY_DOUBLE:
+            out.emplace_back(std::to_string(r->dval));
+            break;
+        case REDIS_REPLY_BOOL:
+            out.emplace_back(r->integer ? "1" : "0");
+            break;
+        case REDIS_REPLY_VERB:
+            out.emplace_back(r->str ? r->str : "");
+            break;
+#endif
+        default:
+            out.emplace_back("");
+        }
+    }
+
+    static std::string gen_uuid() {
+        static thread_local std::mt19937_64 rng{std::random_device{}()};
+        static constexpr char hex[] = "0123456789abcdef";
+        std::uniform_int_distribution<uint64_t> dist;
+
+        auto to_hex = [&](uint64_t x, int bytes) {
+            std::string out;
+            out.reserve(bytes * 2);
+            for (int i = bytes * 2 - 1; i >= 0; --i) {
+                out.push_back(hex[(x >> (i * 4)) & 0xF]);
+            }
+            return out;
+        };
+
+        uint64_t a = dist(rng);
+        uint64_t b = dist(rng);
+
+        // version 4 & variant bits
+        a = (a & 0xFFFFFFFFFFFF0FFFULL) | 0x0000000000004000ULL;
+        b = (b & 0x3FFFFFFFFFFFFFFFULL) | 0x8000000000000000ULL;
+
+        std::string s = to_hex(a >> 32, 4) + "-" +
+                        to_hex(a & 0xFFFFFFFFULL, 4).substr(0,4) + "-" +
+                        to_hex(a & 0xFFFFFFFFULL, 4).substr(4,4) + "-" +
+                        to_hex(b >> 48, 2) + "-" +
+                        to_hex(b & 0x0000FFFFFFFFFFFFULL, 6);
+        return s;
+    }
+
+    void ensure_index(int capacity) {
+        // FT.INFO para checar existência
+        try {
+            std::vector<std::string> info;
+            auto r = redis_->command(std::vector<std::string>{"FT.INFO", index_}.begin(),
+                                     std::vector<std::string>{"FT.INFO", index_}.end());
+            flatten_reply(r.get(), info);
+            (void)info;
+            return;
+        } catch (const sw::redis::Error&) {
+            // não existe, vamos criar
+        }
+
+        std::string dim_str = std::to_string(dim_);
+        std::string algo    = "FLAT"; // ou HNSW
+        std::string cmd_metric = metric_;
+
+        std::vector<std::string> args = {
+            "FT.CREATE", index_,
+            "ON", "HASH",
+            "PREFIX", "1", prefix_,
+            "SCHEMA",
+            "vector", "VECTOR", algo,
+            "6",
+            "TYPE", "FLOAT32",
+            "DIM", dim_str,
+            "DISTANCE_METRIC", cmd_metric,
+            "page", "TEXT",
+            "metadata", "TEXT"
+        };
+
+        if (capacity > 0 && algo == "HNSW") {
+            args.push_back("INITIAL_CAP");
+            args.push_back(std::to_string(capacity));
+        }
+
+        try {
+            redis_->command(args.begin(), args.end());
+        } catch (const sw::redis::Error& e) {
+            throw InvalidConfiguration(std::string("FT.CREATE falhou: ") + e.what());
+        }
+    }
+
+    static std::vector<QueryResult>
+    parse_search_reply(const std::vector<std::string>& raw, const std::string& prefix) {
+        std::vector<QueryResult> out;
+        if (raw.empty()) return out;
+
+        std::size_t idx = 0;
+        const std::size_t total = std::stoull(raw[idx++]);
+
+        for (std::size_t i = 0; i < total && idx < raw.size(); ++i) {
+            const std::string& key = raw[idx++];
+            (void)key;
+
+            std::string page, metadata_json, vector_bin;
+            float score = 0.f;
+
+            while (idx + 1 < raw.size()) {
+                const std::string& field = raw[idx++];
+                const std::string& value = raw[idx++];
+
+                if      (field == "page")     page = value;
+                else if (field == "metadata") metadata_json = value;
+                else if (field == "vector")   vector_bin = value;
+                else if (field == "score")    score = std::stof(value);
+                else {
+                    if (field.rfind(prefix + ":", 0) == 0) { // próximo doc?
+                        idx -= 2;
+                        break;
+                    }
+                }
+
+                if (idx < raw.size() && raw[idx].rfind(prefix + ":", 0) == 0)
+                    break;
+            }
+
+            std::vector<float> emb;
+            if (!vector_bin.empty()) {
+                emb.resize(vector_bin.size() / sizeof(float));
+                std::memcpy(emb.data(), vector_bin.data(), vector_bin.size());
+            }
+
+            auto meta = Document::from_json(metadata_json).metadata;
+            Document doc{page, std::move(emb), std::move(meta)};
+            out.push_back(QueryResult{std::move(doc), score});
+        }
+        return out;
+    }
+};
+
+/* -------- auto-registro -------- */
+static AutoRegister<RedisVectorBackend> _auto_register_redis("redis");
+
+} // namespace vdb

--- a/components/VectorDatabase/src/document.cpp
+++ b/components/VectorDatabase/src/document.cpp
@@ -3,17 +3,15 @@
 
 namespace vdb {
 
-/* ----------------------------- to_json -------------------- */
 std::string Document::to_json() const {
     nlohmann::json j = {
         {"page_content", page_content},
         {"embedding",    embedding},
         {"metadata",     metadata},
     };
-    return j.dump();              // sem indent para ocupar menos espaço
+    return j.dump();              
 }
 
-/* -------------------------- from_json --------------------- */
 Document Document::from_json(std::string_view js) {
     auto j = nlohmann::json::parse(js);
 

--- a/components/VectorDatabase/src/document.cpp
+++ b/components/VectorDatabase/src/document.cpp
@@ -1,0 +1,28 @@
+#include "vectordb/document.h"
+#include <nlohmann/json.hpp>
+
+namespace vdb {
+
+/* ----------------------------- to_json -------------------- */
+std::string Document::to_json() const {
+    nlohmann::json j = {
+        {"page_content", page_content},
+        {"embedding",    embedding},
+        {"metadata",     metadata},
+    };
+    return j.dump();              // sem indent para ocupar menos espaço
+}
+
+/* -------------------------- from_json --------------------- */
+Document Document::from_json(std::string_view js) {
+    auto j = nlohmann::json::parse(js);
+
+    Document d;
+    d.page_content = j.at("page_content").get<std::string>();
+    d.embedding    = j.at("embedding"   ).get<std::vector<float>>();
+    d.metadata     = j.value("metadata",                   // opcional
+                             std::unordered_map<std::string,std::string>{});
+    return d;
+}
+
+} // namespace vdb

--- a/components/VectorDatabase/src/registry.cpp
+++ b/components/VectorDatabase/src/registry.cpp
@@ -9,7 +9,6 @@
 
 namespace {
 
-// normaliza o nome do backend para lowercase
 std::string canonical(std::string n) {
     std::transform(n.begin(), n.end(), n.begin(),
                    [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
@@ -20,13 +19,11 @@ std::string canonical(std::string n) {
 
 namespace vdb {
 
-/* ------------------- singleton (Meyers) ------------------- */
 Registry& Registry::instance() {
     static Registry inst;
     return inst;
 }
 
-/* ------------------- register_backend --------------------- */
 void Registry::register_backend(const std::string& name,
                                 Factory factory,
                                 bool allow_override) {
@@ -40,7 +37,6 @@ void Registry::register_backend(const std::string& name,
     factories_[key] = std::move(factory);
 }
 
-/* ------------------------- make --------------------------- */
 VectorBackendPtr Registry::make(const std::string& name,
                                 const nlohmann::json& cfg) const {
     const std::string key = canonical(name);
@@ -54,7 +50,6 @@ VectorBackendPtr Registry::make(const std::string& name,
     return it->second(cfg);
 }
 
-/* ------------------------- list --------------------------- */
 std::vector<std::string> Registry::list() const {
     std::scoped_lock lock(mtx_);
     std::vector<std::string> keys;

--- a/components/VectorDatabase/src/registry.cpp
+++ b/components/VectorDatabase/src/registry.cpp
@@ -1,0 +1,68 @@
+#include "vectordb/registry.h"
+#include "vectordb/exceptions.h"
+
+#include <algorithm>
+#include <cctype>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace {
+
+// normaliza o nome do backend para lowercase
+std::string canonical(std::string n) {
+    std::transform(n.begin(), n.end(), n.begin(),
+                   [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+    return n;
+}
+
+} // anonymous namespace
+
+namespace vdb {
+
+/* ------------------- singleton (Meyers) ------------------- */
+Registry& Registry::instance() {
+    static Registry inst;
+    return inst;
+}
+
+/* ------------------- register_backend --------------------- */
+void Registry::register_backend(const std::string& name,
+                                Factory factory,
+                                bool allow_override) {
+    const std::string key = canonical(name);
+    std::scoped_lock lock(mtx_);
+
+    if (!allow_override && factories_.find(key) != factories_.end()) {
+        throw InvalidConfiguration("backend '" + key + "' já registrado");
+    }
+
+    factories_[key] = std::move(factory);
+}
+
+/* ------------------------- make --------------------------- */
+VectorBackendPtr Registry::make(const std::string& name,
+                                const nlohmann::json& cfg) const {
+    const std::string key = canonical(name);
+    std::scoped_lock lock(mtx_);
+
+    auto it = factories_.find(key);
+    if (it == factories_.end()) {
+        throw InvalidConfiguration("backend '" + name + "' não encontrado");
+    }
+
+    return it->second(cfg);
+}
+
+/* ------------------------- list --------------------------- */
+std::vector<std::string> Registry::list() const {
+    std::scoped_lock lock(mtx_);
+    std::vector<std::string> keys;
+    keys.reserve(factories_.size());
+    for (const auto& [k, _] : factories_) {
+        keys.push_back(k);
+    }
+    return keys;
+}
+
+} // namespace vdb

--- a/components/VectorDatabase/src/wrappers/concurrent.cpp
+++ b/components/VectorDatabase/src/wrappers/concurrent.cpp
@@ -6,29 +6,26 @@
 
 namespace vdb::wrappers {
 
-/* -------------------------------------------------- ctor/dtor */
 ConcurrentSearchWrapper::ConcurrentSearchWrapper(VectorBackendPtr backend,
                                                  std::size_t      maxWorkers,
                                                  bool             threadSafe)
-    : VectorBackend(backend->dim())          // propagate expected dimension
+    : VectorBackend(backend->dim())          
     , backend_(std::move(backend))
-    , workers_(maxWorkers ? maxWorkers : 1)  // never zero
+    , workers_(maxWorkers ? maxWorkers : 1)  
     , backendThreadSafe_(threadSafe) {}
 
 ConcurrentSearchWrapper::~ConcurrentSearchWrapper() { close(); }
 
-/* -------------------------------------------------- status  */
+
 bool ConcurrentSearchWrapper::is_open() const noexcept {
     return backend_ && backend_->is_open();
 }
 
-/* -------------------------------------------------- insert  */
 void ConcurrentSearchWrapper::insert(std::span<const Document> docs) {
-    std::scoped_lock g(mtx_);        // always serialise inserts
+    std::scoped_lock g(mtx_);        
     backend_->insert(docs);
 }
 
-/* -------------------------------------------------- query  */
 std::vector<QueryResult>
 ConcurrentSearchWrapper::query(std::span<const float>               emb,
                                std::size_t                         k,
@@ -40,7 +37,6 @@ ConcurrentSearchWrapper::query(std::span<const float>               emb,
     return backend_->query(emb, k, filter);
 }
 
-/* -------------------------------------------------- query_many  */
 std::vector<std::vector<QueryResult>>
 ConcurrentSearchWrapper::query_many(const std::vector<std::vector<float>>&            embs,
                                     std::size_t                                       k,
@@ -69,7 +65,6 @@ ConcurrentSearchWrapper::query_many(const std::vector<std::vector<float>>&      
     return out;
 }
 
-/* -------------------------------------------------- close  */
 void ConcurrentSearchWrapper::close() {
     std::scoped_lock g(mtx_);
     if (backend_) {

--- a/components/VectorDatabase/src/wrappers/concurrent.cpp
+++ b/components/VectorDatabase/src/wrappers/concurrent.cpp
@@ -1,0 +1,81 @@
+#include "vectordb/wrappers/concurrent.h"
+#include "vectordb/exceptions.h"
+
+#include <future>
+#include <utility>
+
+namespace vdb::wrappers {
+
+/* -------------------------------------------------- ctor/dtor */
+ConcurrentSearchWrapper::ConcurrentSearchWrapper(VectorBackendPtr backend,
+                                                 std::size_t      maxWorkers,
+                                                 bool             threadSafe)
+    : VectorBackend(backend->dim())          // propagate expected dimension
+    , backend_(std::move(backend))
+    , workers_(maxWorkers ? maxWorkers : 1)  // never zero
+    , backendThreadSafe_(threadSafe) {}
+
+ConcurrentSearchWrapper::~ConcurrentSearchWrapper() { close(); }
+
+/* -------------------------------------------------- status  */
+bool ConcurrentSearchWrapper::is_open() const noexcept {
+    return backend_ && backend_->is_open();
+}
+
+/* -------------------------------------------------- insert  */
+void ConcurrentSearchWrapper::insert(std::span<const Document> docs) {
+    std::scoped_lock g(mtx_);        // always serialise inserts
+    backend_->insert(docs);
+}
+
+/* -------------------------------------------------- query  */
+std::vector<QueryResult>
+ConcurrentSearchWrapper::query(std::span<const float>               emb,
+                               std::size_t                         k,
+                               const std::unordered_map<std::string, std::string>* filter) {
+    if (!backendThreadSafe_) {
+        std::scoped_lock g(mtx_);
+        return backend_->query(emb, k, filter);
+    }
+    return backend_->query(emb, k, filter);
+}
+
+/* -------------------------------------------------- query_many  */
+std::vector<std::vector<QueryResult>>
+ConcurrentSearchWrapper::query_many(const std::vector<std::vector<float>>&            embs,
+                                    std::size_t                                       k,
+                                    const std::unordered_map<std::string, std::string>* filter,
+                                    bool                                              raiseOnErr) {
+    std::vector<std::future<std::vector<QueryResult>>> futs;
+    futs.reserve(embs.size());
+
+    /* launch each search in its own async task (simple pool) */
+    for (const auto& v : embs) {
+        futs.emplace_back(std::async(std::launch::async, [&, vec = v]() {
+            return query(vec, k, filter);
+        }));
+    }
+
+    /* collect preserving order */
+    std::vector<std::vector<QueryResult>> out(embs.size());
+    for (std::size_t i = 0; i < futs.size(); ++i) {
+        try {
+            out[i] = futs[i].get();
+        } catch (...) {
+            if (raiseOnErr) throw;     // propagate first exception
+            out[i].clear();            // else: empty result set
+        }
+    }
+    return out;
+}
+
+/* -------------------------------------------------- close  */
+void ConcurrentSearchWrapper::close() {
+    std::scoped_lock g(mtx_);
+    if (backend_) {
+        backend_->close();
+        backend_.reset();
+    }
+}
+
+}  // namespace vdb::wrappers

--- a/components/VectorDatabase/src/wrappers/metrics.cpp
+++ b/components/VectorDatabase/src/wrappers/metrics.cpp
@@ -13,7 +13,6 @@ using namespace std::chrono;
 
 namespace vdb::wrappers {
 
-/* ----------------------------- CallStats ------------------- */
 void CallStats::observe(double elapsed, bool ok) noexcept {
     ++calls;
     if (!ok) ++errors;
@@ -22,16 +21,13 @@ void CallStats::observe(double elapsed, bool ok) noexcept {
     max_t  = std::max(max_t, elapsed);
 }
 
-/* ----------------------------- ctor ------------------------ */
 MetricsWrapper::MetricsWrapper(VectorBackendPtr backend, std::string ns)
     : VectorBackend(backend->dim())
     , backend_(std::move(backend))
     , ns_(std::move(ns)) {}
 
-/* ----------------------------- status ---------------------- */
 bool MetricsWrapper::is_open() const noexcept { return backend_->is_open(); }
 
-/* ----------------------------- measure() ------------------- */
 template <typename F, typename... Args>
 auto MetricsWrapper::measure(const std::string& method, F&& fn, Args&&... args) {
     const auto start = steady_clock::now();
@@ -63,12 +59,10 @@ auto MetricsWrapper::measure(const std::string& method, F&& fn, Args&&... args) 
     }
 }
 
-/* ----------------------------- insert ---------------------- */
 void MetricsWrapper::insert(std::span<const Document> docs) {
     measure("insert", &VectorBackend::insert, backend_.get(), docs);
 }
 
-/* ----------------------------- query ----------------------- */
 std::vector<QueryResult>
 MetricsWrapper::query(std::span<const float> emb,
                       std::size_t            k,
@@ -76,12 +70,10 @@ MetricsWrapper::query(std::span<const float> emb,
     return measure("query", &VectorBackend::query, backend_.get(), emb, k, filter);
 }
 
-/* ----------------------------- close ----------------------- */
 void MetricsWrapper::close() {
     measure("close", &VectorBackend::close, backend_.get());
 }
 
-/* ----------------------------- snapshot -------------------- */
 std::unordered_map<std::string, CallStats> MetricsWrapper::snapshot() const {
     std::scoped_lock g(mtx_);
     return stats_;

--- a/components/VectorDatabase/src/wrappers/metrics.cpp
+++ b/components/VectorDatabase/src/wrappers/metrics.cpp
@@ -1,0 +1,111 @@
+#include "vectordb/wrappers/metrics.h"
+#include "vectordb/exceptions.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+using namespace std::chrono;
+
+namespace vdb::wrappers {
+
+/* ----------------------------- CallStats ------------------- */
+void CallStats::observe(double elapsed, bool ok) noexcept {
+    ++calls;
+    if (!ok) ++errors;
+    total += elapsed;
+    min_t  = std::min(min_t, elapsed);
+    max_t  = std::max(max_t, elapsed);
+}
+
+/* ----------------------------- ctor ------------------------ */
+MetricsWrapper::MetricsWrapper(VectorBackendPtr backend, std::string ns)
+    : VectorBackend(backend->dim())
+    , backend_(std::move(backend))
+    , ns_(std::move(ns)) {}
+
+/* ----------------------------- status ---------------------- */
+bool MetricsWrapper::is_open() const noexcept { return backend_->is_open(); }
+
+/* ----------------------------- measure() ------------------- */
+template <typename F, typename... Args>
+auto MetricsWrapper::measure(const std::string& method, F&& fn, Args&&... args) {
+    const auto start = steady_clock::now();
+    bool ok = true;
+
+    using R = std::invoke_result_t<F, Args...>;
+    try {
+        if constexpr (std::is_void_v<R>) {
+            std::invoke(std::forward<F>(fn), std::forward<Args>(args)...);
+            const auto elapsed = duration<double>(steady_clock::now() - start).count();
+            std::scoped_lock g(mtx_);
+            stats_[method].observe(elapsed, ok);
+            return; // void
+        } else {
+            R result = std::invoke(std::forward<F>(fn), std::forward<Args>(args)...);
+            const auto elapsed = duration<double>(steady_clock::now() - start).count();
+            std::scoped_lock g(mtx_);
+            stats_[method].observe(elapsed, ok);
+            return result;
+        }
+    } catch (...) {
+        ok = false;
+        const auto elapsed = duration<double>(steady_clock::now() - start).count();
+        {
+            std::scoped_lock g(mtx_);
+            stats_[method].observe(elapsed, ok);
+        }
+        throw;
+    }
+}
+
+/* ----------------------------- insert ---------------------- */
+void MetricsWrapper::insert(std::span<const Document> docs) {
+    measure("insert", &VectorBackend::insert, backend_.get(), docs);
+}
+
+/* ----------------------------- query ----------------------- */
+std::vector<QueryResult>
+MetricsWrapper::query(std::span<const float> emb,
+                      std::size_t            k,
+                      const std::unordered_map<std::string, std::string>* filter) {
+    return measure("query", &VectorBackend::query, backend_.get(), emb, k, filter);
+}
+
+/* ----------------------------- close ----------------------- */
+void MetricsWrapper::close() {
+    measure("close", &VectorBackend::close, backend_.get());
+}
+
+/* ----------------------------- snapshot -------------------- */
+std::unordered_map<std::string, CallStats> MetricsWrapper::snapshot() const {
+    std::scoped_lock g(mtx_);
+    return stats_;
+}
+
+std::string MetricsWrapper::snapshot_json(int indent) const {
+    nlohmann::json j;
+    auto snap = snapshot();
+    for (auto& [k, s] : snap) {
+        j[k] = {
+            {"calls",  s.calls},
+            {"errors", s.errors},
+            {"total",  s.total},
+            {"min",    std::isinf(s.min_t) ? nlohmann::json(nullptr) : nlohmann::json(s.min_t)},
+            {"max",    s.max_t},
+            {"avg",    s.calls ? s.total / s.calls : 0.0}
+        };
+    }
+    return j.dump(indent);
+}
+
+void MetricsWrapper::reset() {
+    std::scoped_lock g(mtx_);
+    stats_.clear();
+}
+
+} // namespace vdb::wrappers

--- a/conanfile.py
+++ b/conanfile.py
@@ -39,6 +39,8 @@ class RagPureAIConan(ConanFile):
         self.requires("onnxruntime/1.18.1")
         self.requires("nlohmann_json/3.11.3")
         self.requires("libcurl/8.10.1")
+        self.requires("redis-plus-plus/1.3.13")
+
 
     def configure(self):
         if self.options.CURL_STATIC_LINKING:


### PR DESCRIPTION
# PR: Redis Backend for VectorDatabase (Modular Architecture)

### Summary
This PR introduces a modular architecture for vector backends and adds the first concrete implementation: Redis (with RediSearch).
The goal is to enable easy plug-in of new backends (e.g., Oracle, PGVector, Milvus) while maintaining a consistent C++/Python contract.

### What was done

- **Common Interface (`VectorBackend`) + Registry** to register and instantiate backends by name.
- **`redis_backend.cpp` implementation** (insertion, KNN search via `FT.SEARCH`, metadata serialization, etc.).
- **Python bindings with PyBind11 (`vectordb`)**:
    - `make_backend(name, cfg_json)` and `list_backends()`.
    - `Document` and `QueryResult` classes.
- A minimal Python example demonstrating insert/query operations.
- CMake adjustments to compile the Python module (`vectordb.cpython-*.so`).

### How to Run (Docker Recommended)

1.  **Build the image**
    ```bash
    docker build -t purecpp .
    ```

2.  **Create a network** (so Redis and the project container can see each other)
    ```bash
    docker network create purecpp-net
    ```

3.  **Start Redis** (RedisStack with RediSearch)
    ```bash
    docker run -d --name redis-stack \
      --network purecpp-net \
      -p 6379:6379 -p 8001:8001 \
      redis/redis-stack-server:latest
    ```
    *Optional UI at http://localhost:8001/*

4.  **Enter the project container**
    ```bash
    docker run -it --rm \
      --network purecpp-net \
      -v $(pwd):/app \
      purecpp bash
    ```

5.  **Build inside the container**
    ```bash
    ./build.sh
    cmake --build --preset conan-release --target vectordb -j"$(nproc)"
    ```

6.  **Run the Python example**
    ```bash
    export PYTHONPATH=/app/build/Release/python:$PYTHONPATH
    python3 - <<'PY'
    import json, vectordb
    from vectordb import Document

    cfg = {"uri":"redis://redis-stack:6379", "index":"test_idx", "prefix":"doc", "dim":4, "metric":"COSINE"}
    db  = vectordb.make_backend("redis", json.dumps(cfg))

    docs = [
        Document("primeiro texto", [0.1,0.2,0.3,0.4], {"id":"1"}),
        Document("segundo texto",  [0.9,0.1,0.0,0.2], {"id":"2"}),
    ]
    db.insert(docs)

    res = db.query([0.1,0.2,0.25,0.35], k=2)
    for i, r in enumerate(res, 1):
        print(i, r.score, r.doc.page_content, r.doc.metadata)

    db.close()
    PY
    ```
    **Expected output** (score values may vary, but the order should be correct):
    ```
    1 0.00195223 primeiro texto {'id': '1'}
    2 0.59960436 segundo texto {'id': '2'}
    ```

### Cleanup / Reset Index (Optional)

Inside the RedisStack container:
```bash
# Drop the index and delete all documents with the "DD" option
docker exec -it redis-stack redis-cli FT.DROPINDEX test_idx DD

# Flush the entire Redis database
docker exec -it redis-stack redis-cli FLUSHDB
```
### Troubleshooting

Name or service not known: Containers are in different networks. Ensure --network purecpp-net is used for both run commands.

FT.CREATE failed / failed to connect to Redis: Incorrect URI or the Redis container is not running.

Repeated/0.0 scores: Make sure you are:

Using SORTBY score ASC.

Passing vec_bin in the PARAMS clause.

Using the updated RETURN "4" "page" "metadata" "vector" "score" clause.

### Next Steps

[ ] Add a Python overload to accept a dict directly (without json.dumps).

[ ] Implement an Oracle Vector DB backend following the same contract.

[ ] Add automated tests (pytest or ctest) for insertion and querying.

[ ] Encapsulate the document schema into a class.

[ ] Implement a more sophisticated import mode, such as from purecpp.vectordb import Redisdb.

### Checklist

[x] Functional Redis backend

[x] Stable API (Document, QueryResult, VectorBackend)

[x] Docker instructions + Python example

[ ] Documentation in the main README